### PR TITLE
Added seperate desctiption supporting multilines

### DIFF
--- a/flask-instanced-alpine3.19/Makefile
+++ b/flask-instanced-alpine3.19/Makefile
@@ -14,7 +14,7 @@ kill: ckill skill
 export FULLNAME = CTFd challenge name
 export AUTHOR   = CTFd author
 export CATEGORY = pwn
-export DESC     = CTFd description
+export DESC     = $(shell cat challenge/description.txt | sed '{:q;N;s/\n/<br>/g;t q}')
 export FLAG     = $(shell cat challenge/flag.txt)
 export TAG      = CTFd tag
 
@@ -166,6 +166,7 @@ deploy: deploy-registry
 
 deploy-yml:
 	@echo -e "\e[1;34m[+] Generating CTFd challenge yml\e[0m"
+	@printf %s "${DESC}"
 	envsubst < ${MKPATH}/deployment/ctfd-entry.yml.template | \
 		tee ${MKPATH}/deployment/ctfd-${NAME}.yml >/dev/null
 

--- a/flask-instanced-alpine3.19/challenge/description.txt
+++ b/flask-instanced-alpine3.19/challenge/description.txt
@@ -1,0 +1,1 @@
+CTFd description

--- a/flask-nojail-alpine3.19/Makefile
+++ b/flask-nojail-alpine3.19/Makefile
@@ -14,7 +14,7 @@ kill: ckill skill
 export FULLNAME = CTFd challenge name
 export AUTHOR   = CTFd author
 export CATEGORY = pwn
-export DESC     = CTFd description
+export DESC     = $(shell cat challenge/description.txt | sed '{:q;N;s/\n/<br>/g;t q}')
 export FLAG     = $(shell cat challenge/flag.txt)
 export TAG      = CTFd tag
 

--- a/flask-nojail-alpine3.19/challenge/description.txt
+++ b/flask-nojail-alpine3.19/challenge/description.txt
@@ -1,0 +1,1 @@
+CTFd description

--- a/offline/Makefile
+++ b/offline/Makefile
@@ -14,7 +14,7 @@ kill: ckill skill
 export FULLNAME = CTFd challenge name
 export AUTHOR   = CTFd author
 export CATEGORY = pwn
-export DESC     = CTFd description
+export DESC     = $(shell cat challenge/description.txt | sed '{:q;N;s/\n/<br>/g;t q}')
 export FLAG     = $(shell cat challenge/flag.txt)
 export TAG      = CTFd tag
 

--- a/php-instanced-ubuntu24.04/Makefile
+++ b/php-instanced-ubuntu24.04/Makefile
@@ -14,7 +14,7 @@ kill: ckill skill
 export FULLNAME = CTFd challenge name
 export AUTHOR   = CTFd author
 export CATEGORY = pwn
-export DESC     = CTFd description
+export DESC     = $(shell cat challenge/description.txt | sed '{:q;N;s/\n/<br>/g;t q}')
 export FLAG     = $(shell cat challenge/flag.txt)
 export TAG      = CTFd tag
 

--- a/php-instanced-ubuntu24.04/challenge/description.txt
+++ b/php-instanced-ubuntu24.04/challenge/description.txt
@@ -1,0 +1,1 @@
+CTFd description

--- a/php-nojail-ubuntu24.04/Makefile
+++ b/php-nojail-ubuntu24.04/Makefile
@@ -14,7 +14,7 @@ kill: ckill skill
 export FULLNAME = CTFd challenge name
 export AUTHOR   = CTFd author
 export CATEGORY = pwn
-export DESC     = CTFd description
+export DESC     = $(shell cat challenge/description.txt | sed '{:q;N;s/\n/<br>/g;t q}')
 export FLAG     = $(shell cat challenge/flag.txt)
 export TAG      = CTFd tag
 

--- a/php-nojail-ubuntu24.04/challenge/description.txt
+++ b/php-nojail-ubuntu24.04/challenge/description.txt
@@ -1,0 +1,1 @@
+CTFd description

--- a/phpxss-nojail-ubuntu24.04/Makefile
+++ b/phpxss-nojail-ubuntu24.04/Makefile
@@ -14,7 +14,7 @@ kill: ckill skill
 export FULLNAME = CTFd challenge name
 export AUTHOR   = CTFd author
 export CATEGORY = pwn
-export DESC     = CTFd description
+export DESC     = $(shell cat challenge/description.txt | sed '{:q;N;s/\n/<br>/g;t q}')
 export FLAG     = $(shell cat challenge/flag.txt)
 export TAG      = CTFd tag
 

--- a/phpxss-nojail-ubuntu24.04/challenge/description.txt
+++ b/phpxss-nojail-ubuntu24.04/challenge/description.txt
@@ -1,0 +1,1 @@
+CTFd description

--- a/pwn-jail-alpine3.19/Makefile
+++ b/pwn-jail-alpine3.19/Makefile
@@ -14,7 +14,7 @@ kill: ckill skill
 export FULLNAME = CTFd challenge name
 export AUTHOR   = CTFd author
 export CATEGORY = pwn
-export DESC     = CTFd description
+export DESC     = $(shell cat challenge/description.txt | sed '{:q;N;s/\n/<br>/g;t q}')
 export FLAG     = $(shell cat challenge/flag.txt)
 export TAG      = CTFd tag
 

--- a/pwn-jail-alpine3.19/challenge/description.txt
+++ b/pwn-jail-alpine3.19/challenge/description.txt
@@ -1,0 +1,1 @@
+CTFd description

--- a/pwn-jail-ubuntu24.04/Makefile
+++ b/pwn-jail-ubuntu24.04/Makefile
@@ -14,7 +14,7 @@ kill: ckill skill
 export FULLNAME = CTFd challenge name
 export AUTHOR   = CTFd author
 export CATEGORY = pwn
-export DESC     = CTFd description
+export DESC     = $(shell cat challenge/description.txt | sed '{:q;N;s/\n/<br>/g;t q}')
 export FLAG     = $(shell cat challenge/flag.txt)
 export TAG      = CTFd tag
 

--- a/pwn-jail-ubuntu24.04/challenge/description.txt
+++ b/pwn-jail-ubuntu24.04/challenge/description.txt
@@ -1,0 +1,1 @@
+CTFd description

--- a/pwn-nojail-alpine3.19/Makefile
+++ b/pwn-nojail-alpine3.19/Makefile
@@ -14,7 +14,7 @@ kill: ckill skill
 export FULLNAME = CTFd challenge name
 export AUTHOR   = CTFd author
 export CATEGORY = pwn
-export DESC     = CTFd description
+export DESC     = $(shell cat challenge/description.txt | sed '{:q;N;s/\n/<br>/g;t q}')
 export FLAG     = $(shell cat challenge/flag.txt)
 export TAG      = CTFd tag
 

--- a/pwn-nojail-alpine3.19/challenge/description.txt
+++ b/pwn-nojail-alpine3.19/challenge/description.txt
@@ -1,0 +1,1 @@
+CTFd description

--- a/pwn-nojail-ubuntu24.04/Makefile
+++ b/pwn-nojail-ubuntu24.04/Makefile
@@ -14,7 +14,7 @@ kill: ckill skill
 export FULLNAME = CTFd challenge name
 export AUTHOR   = CTFd author
 export CATEGORY = pwn
-export DESC     = CTFd description
+export DESC     = $(shell cat challenge/description.txt | sed '{:q;N;s/\n/<br>/g;t q}')
 export FLAG     = $(shell cat challenge/flag.txt)
 export TAG      = CTFd tag
 

--- a/pwn-nojail-ubuntu24.04/challenge/description.txt
+++ b/pwn-nojail-ubuntu24.04/challenge/description.txt
@@ -1,0 +1,1 @@
+CTFd description

--- a/pwn-qemu-kernel/Makefile
+++ b/pwn-qemu-kernel/Makefile
@@ -14,7 +14,7 @@ kill: ckill skill
 export FULLNAME = CTFd challenge name
 export AUTHOR   = CTFd author
 export CATEGORY = pwn
-export DESC     = CTFd description
+export DESC     = $(shell cat challenge/description.txt | sed '{:q;N;s/\n/<br>/g;t q}')
 export FLAG     = $(shell cat challenge/flag.txt)
 export TAG      = CTFd tag
 

--- a/pwn-qemu-kernel/challenge/description.txt
+++ b/pwn-qemu-kernel/challenge/description.txt
@@ -1,0 +1,1 @@
+CTFd description

--- a/python3.11-jail-alpine3.19/Makefile
+++ b/python3.11-jail-alpine3.19/Makefile
@@ -14,7 +14,7 @@ kill: ckill skill
 export FULLNAME = CTFd challenge name
 export AUTHOR   = CTFd author
 export CATEGORY = pwn
-export DESC     = CTFd description
+export DESC     = $(shell cat challenge/description.txt | sed '{:q;N;s/\n/<br>/g;t q}')
 export FLAG     = $(shell cat challenge/flag.txt)
 export TAG      = CTFd tag
 

--- a/python3.11-jail-alpine3.19/challenge/description.txt
+++ b/python3.11-jail-alpine3.19/challenge/description.txt
@@ -1,0 +1,1 @@
+CTFd description

--- a/python3.11-nojail-alpine3.19/Makefile
+++ b/python3.11-nojail-alpine3.19/Makefile
@@ -14,7 +14,7 @@ kill: ckill skill
 export FULLNAME = CTFd challenge name
 export AUTHOR   = CTFd author
 export CATEGORY = pwn
-export DESC     = CTFd description
+export DESC     = $(shell cat challenge/description.txt | sed '{:q;N;s/\n/<br>/g;t q}')
 export FLAG     = $(shell cat challenge/flag.txt)
 export TAG      = CTFd tag
 

--- a/python3.11-nojail-alpine3.19/challenge/description.txt
+++ b/python3.11-nojail-alpine3.19/challenge/description.txt
@@ -1,0 +1,1 @@
+CTFd description

--- a/python3.12-jail-ubuntu24.04/Makefile
+++ b/python3.12-jail-ubuntu24.04/Makefile
@@ -14,7 +14,7 @@ kill: ckill skill
 export FULLNAME = CTFd challenge name
 export AUTHOR   = CTFd author
 export CATEGORY = pwn
-export DESC     = CTFd description
+export DESC     = $(shell cat challenge/description.txt | sed '{:q;N;s/\n/<br>/g;t q}')
 export FLAG     = $(shell cat challenge/flag.txt)
 export TAG      = CTFd tag
 

--- a/python3.12-jail-ubuntu24.04/challenge/description.txt
+++ b/python3.12-jail-ubuntu24.04/challenge/description.txt
@@ -1,0 +1,1 @@
+CTFd description

--- a/python3.12-nojail-ubuntu24.04/Makefile
+++ b/python3.12-nojail-ubuntu24.04/Makefile
@@ -14,7 +14,7 @@ kill: ckill skill
 export FULLNAME = CTFd challenge name
 export AUTHOR   = CTFd author
 export CATEGORY = pwn
-export DESC     = CTFd description
+export DESC     = $(shell cat challenge/description.txt | sed '{:q;N;s/\n/<br>/g;t q}')
 export FLAG     = $(shell cat challenge/flag.txt)
 export TAG      = CTFd tag
 

--- a/python3.12-nojail-ubuntu24.04/challenge/description.txt
+++ b/python3.12-nojail-ubuntu24.04/challenge/description.txt
@@ -1,0 +1,1 @@
+CTFd description

--- a/rust-nojail-alpine3.19/Makefile
+++ b/rust-nojail-alpine3.19/Makefile
@@ -14,7 +14,7 @@ kill: ckill skill
 export FULLNAME = CTFd challenge name
 export AUTHOR   = CTFd author
 export CATEGORY = pwn
-export DESC     = CTFd description
+export DESC     = $(shell cat challenge/description.txt | sed '{:q;N;s/\n/<br>/g;t q}')
 export FLAG     = $(shell cat challenge/flag.txt)
 export TAG      = CTFd tag
 

--- a/rust-nojail-alpine3.19/challenge/description.txt
+++ b/rust-nojail-alpine3.19/challenge/description.txt
@@ -1,0 +1,1 @@
+CTFd description

--- a/rust-nojail-ubuntu24.04/Makefile
+++ b/rust-nojail-ubuntu24.04/Makefile
@@ -14,7 +14,7 @@ kill: ckill skill
 export FULLNAME = CTFd challenge name
 export AUTHOR   = CTFd author
 export CATEGORY = pwn
-export DESC     = CTFd description
+export DESC     = $(shell cat challenge/description.txt | sed '{:q;N;s/\n/<br>/g;t q}')
 export FLAG     = $(shell cat challenge/flag.txt)
 export TAG      = CTFd tag
 

--- a/rust-nojail-ubuntu24.04/challenge/description.txt
+++ b/rust-nojail-ubuntu24.04/challenge/description.txt
@@ -1,0 +1,1 @@
+CTFd description

--- a/sagemath-nojail-ubuntu22.04/Makefile
+++ b/sagemath-nojail-ubuntu22.04/Makefile
@@ -14,7 +14,7 @@ kill: ckill skill
 export FULLNAME = CTFd challenge name
 export AUTHOR   = CTFd author
 export CATEGORY = pwn
-export DESC     = CTFd description
+export DESC     = $(shell cat challenge/description.txt | sed '{:q;N;s/\n/<br>/g;t q}')
 export FLAG     = $(shell cat challenge/flag.txt)
 export TAG      = CTFd tag
 

--- a/sagemath-nojail-ubuntu22.04/challenge/description.txt
+++ b/sagemath-nojail-ubuntu22.04/challenge/description.txt
@@ -1,0 +1,1 @@
+CTFd description

--- a/solidity-nojail-debian11/Makefile
+++ b/solidity-nojail-debian11/Makefile
@@ -14,7 +14,7 @@ kill: ckill skill
 export FULLNAME = CTFd challenge name
 export AUTHOR   = CTFd author
 export CATEGORY = smartcontract
-export DESC     = CTFd description
+export DESC     = $(shell cat challenge/description.txt | sed '{:q;N;s/\n/<br>/g;t q}')
 export FLAG     = $(shell cat challenge/flag.txt)
 export TAG      = CTFd tag
 

--- a/solidity-nojail-debian11/challenge/description.txt
+++ b/solidity-nojail-debian11/challenge/description.txt
@@ -1,0 +1,1 @@
+CTFd description


### PR DESCRIPTION
This PR introduces what I mentioned in #19.
The description is moved into a seperate file, newlines are replaced with `<br>` which CTFd is able to display.

As an example, the following Content in `description.txt`
```
This is a
multiline description.

:)
```
results in `description: This is a<br>multiline description.<br><br>:)` in the templated `challenge.yml`.

This results in the following challenge-description:
![image](https://github.com/user-attachments/assets/2d869e70-8604-409e-aa73-0091c1f3192b)


Directly using the content of the file and using the multiline-prefix that ctfcli supports (`description =|`)didn't work for me, I suspect that the issue is the environment.

Closes #19 