### PR TITLE
Added autor as part of the description

### DIFF
--- a/flask-instanced-alpine3.19/deployment/ctfd-entry.yml.template
+++ b/flask-instanced-alpine3.19/deployment/ctfd-entry.yml.template
@@ -2,7 +2,7 @@ name: "${FULLNAME}"
 author: "${AUTHOR}"
 category: "${CATEGORY}"
 
-description: ${DESC}<br><br>Autor: ${AUTHOR}
+description: ${DESC}<br><br>Author: ${AUTHOR}
 
 type: "dynamic"
 value: 500

--- a/flask-nojail-alpine3.19/deployment/ctfd-entry.yml.template
+++ b/flask-nojail-alpine3.19/deployment/ctfd-entry.yml.template
@@ -2,7 +2,7 @@ name: "${FULLNAME}"
 author: "${AUTHOR}"
 category: "${CATEGORY}"
 
-description: ${DESC}<br><br>Autor: ${AUTHOR}
+description: ${DESC}<br><br>Author: ${AUTHOR}
 
 type: "dynamic"
 value: 500

--- a/offline/deployment/ctfd-entry.yml.template
+++ b/offline/deployment/ctfd-entry.yml.template
@@ -2,7 +2,7 @@ name: "${FULLNAME}"
 author: "${AUTHOR}"
 category: "${CATEGORY}"
 
-description: ${DESC}<br><br>Autor: ${AUTHOR}
+description: ${DESC}<br><br>Author: ${AUTHOR}
 
 type: "dynamic"
 value: 500

--- a/php-instanced-ubuntu24.04/deployment/ctfd-entry.yml.template
+++ b/php-instanced-ubuntu24.04/deployment/ctfd-entry.yml.template
@@ -2,7 +2,7 @@ name: "${FULLNAME}"
 author: "${AUTHOR}"
 category: "${CATEGORY}"
 
-description: ${DESC}<br><br>Autor: ${AUTHOR}
+description: ${DESC}<br><br>Author: ${AUTHOR}
 
 type: "dynamic"
 value: 500

--- a/php-nojail-ubuntu24.04/deployment/ctfd-entry.yml.template
+++ b/php-nojail-ubuntu24.04/deployment/ctfd-entry.yml.template
@@ -2,7 +2,7 @@ name: "${FULLNAME}"
 author: "${AUTHOR}"
 category: "${CATEGORY}"
 
-description: ${DESC}<br><br>Autor: ${AUTHOR}
+description: ${DESC}<br><br>Author: ${AUTHOR}
 
 type: "dynamic"
 value: 500

--- a/phpxss-nojail-ubuntu24.04/deployment/ctfd-entry.yml.template
+++ b/phpxss-nojail-ubuntu24.04/deployment/ctfd-entry.yml.template
@@ -2,7 +2,7 @@ name: "${FULLNAME}"
 author: "${AUTHOR}"
 category: "${CATEGORY}"
 
-description: ${DESC}<br><br>Autor: ${AUTHOR}
+description: ${DESC}<br><br>Author: ${AUTHOR}
 
 type: "dynamic"
 value: 500

--- a/pwn-jail-alpine3.19/deployment/ctfd-entry.yml.template
+++ b/pwn-jail-alpine3.19/deployment/ctfd-entry.yml.template
@@ -2,7 +2,7 @@ name: "${FULLNAME}"
 author: "${AUTHOR}"
 category: "${CATEGORY}"
 
-description: ${DESC}<br><br>Autor: ${AUTHOR}
+description: ${DESC}<br><br>Author: ${AUTHOR}
 
 type: "dynamic"
 value: 500

--- a/pwn-jail-ubuntu24.04/deployment/ctfd-entry.yml.template
+++ b/pwn-jail-ubuntu24.04/deployment/ctfd-entry.yml.template
@@ -2,7 +2,7 @@ name: "${FULLNAME}"
 author: "${AUTHOR}"
 category: "${CATEGORY}"
 
-description: ${DESC}<br><br>Autor: ${AUTHOR}<br><br>Autor: ${AUTHOR}
+description: ${DESC}<br><br>Author: ${AUTHOR}
 
 type: "dynamic"
 value: 500

--- a/pwn-nojail-alpine3.19/deployment/ctfd-entry.yml.template
+++ b/pwn-nojail-alpine3.19/deployment/ctfd-entry.yml.template
@@ -2,7 +2,7 @@ name: "${FULLNAME}"
 author: "${AUTHOR}"
 category: "${CATEGORY}"
 
-description: ${DESC}<br><br>Autor: ${AUTHOR}
+description: ${DESC}<br><br>Author: ${AUTHOR}
 
 type: "dynamic"
 value: 500

--- a/pwn-nojail-ubuntu24.04/deployment/ctfd-entry.yml.template
+++ b/pwn-nojail-ubuntu24.04/deployment/ctfd-entry.yml.template
@@ -2,7 +2,7 @@ name: "${FULLNAME}"
 author: "${AUTHOR}"
 category: "${CATEGORY}"
 
-description: ${DESC}<br><br>Autor: ${AUTHOR}
+description: ${DESC}<br><br>Author: ${AUTHOR}
 
 type: "dynamic"
 value: 500

--- a/pwn-qemu-kernel/deployment/ctfd-entry.yml.template
+++ b/pwn-qemu-kernel/deployment/ctfd-entry.yml.template
@@ -2,7 +2,7 @@ name: "${FULLNAME}"
 author: "${AUTHOR}"
 category: "${CATEGORY}"
 
-description: ${DESC}<br><br>Autor: ${AUTHOR}
+description: ${DESC}<br><br>Author: ${AUTHOR}
 
 type: "dynamic"
 value: 500

--- a/python3.11-jail-alpine3.19/deployment/ctfd-entry.yml.template
+++ b/python3.11-jail-alpine3.19/deployment/ctfd-entry.yml.template
@@ -2,7 +2,7 @@ name: "${FULLNAME}"
 author: "${AUTHOR}"
 category: "${CATEGORY}"
 
-description: ${DESC}<br><br>Autor: ${AUTHOR}
+description: ${DESC}<br><br>Author: ${AUTHOR}
 
 type: "dynamic"
 value: 500

--- a/python3.11-nojail-alpine3.19/deployment/ctfd-entry.yml.template
+++ b/python3.11-nojail-alpine3.19/deployment/ctfd-entry.yml.template
@@ -2,7 +2,7 @@ name: "${FULLNAME}"
 author: "${AUTHOR}"
 category: "${CATEGORY}"
 
-description: ${DESC}<br><br>Autor: ${AUTHOR}
+description: ${DESC}<br><br>Author: ${AUTHOR}
 
 type: "dynamic"
 value: 500

--- a/python3.12-jail-ubuntu24.04/deployment/ctfd-entry.yml.template
+++ b/python3.12-jail-ubuntu24.04/deployment/ctfd-entry.yml.template
@@ -2,7 +2,7 @@ name: "${FULLNAME}"
 author: "${AUTHOR}"
 category: "${CATEGORY}"
 
-description: ${DESC}<br><br>Autor: ${AUTHOR}
+description: ${DESC}<br><br>Author: ${AUTHOR}
 
 type: "dynamic"
 value: 500

--- a/python3.12-nojail-ubuntu24.04/deployment/ctfd-entry.yml.template
+++ b/python3.12-nojail-ubuntu24.04/deployment/ctfd-entry.yml.template
@@ -2,7 +2,7 @@ name: "${FULLNAME}"
 author: "${AUTHOR}"
 category: "${CATEGORY}"
 
-description: ${DESC}<br><br>Autor: ${AUTHOR}
+description: ${DESC}<br><br>Author: ${AUTHOR}
 
 type: "dynamic"
 value: 500

--- a/rust-nojail-alpine3.19/deployment/ctfd-entry.yml.template
+++ b/rust-nojail-alpine3.19/deployment/ctfd-entry.yml.template
@@ -2,7 +2,7 @@ name: "${FULLNAME}"
 author: "${AUTHOR}"
 category: "${CATEGORY}"
 
-description: ${DESC}<br><br>Autor: ${AUTHOR}
+description: ${DESC}<br><br>Author: ${AUTHOR}
 
 type: "dynamic"
 value: 500

--- a/rust-nojail-ubuntu24.04/deployment/ctfd-entry.yml.template
+++ b/rust-nojail-ubuntu24.04/deployment/ctfd-entry.yml.template
@@ -2,7 +2,7 @@ name: "${FULLNAME}"
 author: "${AUTHOR}"
 category: "${CATEGORY}"
 
-description: ${DESC}<br><br>Autor: ${AUTHOR}
+description: ${DESC}<br><br>Author: ${AUTHOR}
 
 type: "dynamic"
 value: 500

--- a/sagemath-nojail-ubuntu22.04/deployment/ctfd-entry.yml.template
+++ b/sagemath-nojail-ubuntu22.04/deployment/ctfd-entry.yml.template
@@ -2,7 +2,7 @@ name: "${FULLNAME}"
 author: "${AUTHOR}"
 category: "${CATEGORY}"
 
-description: ${DESC}<br><br>Autor: ${AUTHOR}
+description: ${DESC}<br><br>Author: ${AUTHOR}
 
 type: "dynamic"
 value: 500

--- a/solidity-nojail-debian11/deployment/ctfd-entry.yml.template
+++ b/solidity-nojail-debian11/deployment/ctfd-entry.yml.template
@@ -2,7 +2,7 @@ name: "${FULLNAME}"
 author: "${AUTHOR}"
 category: "${CATEGORY}"
 
-description: ${DESC}<br><br>Autor: ${AUTHOR}
+description: ${DESC}<br><br>Author: ${AUTHOR}
 
 type: "dynamic"
 value: 500


### PR DESCRIPTION
This PR adds the autor as part of the challenge-description.
I am aware that there exists a `Attribution`-Field, but I didn't find out where this attribution is shown therfore I added automation to archive what we are doing in KaindorfCTF and previous editions of GlacierCTF

Preview of the change with default autor and description
![image](https://github.com/user-attachments/assets/bdc9b744-4267-44e8-adea-d01714962df8)
