### PR TITLE
Makefile target to generate a table of versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: get_versions
+
+NAME_LENGTH:=30
+VERSION_LENGTH:=7
+
+get_versions:
+	$(eval NAME_SEPERATOR := $(shell printf -- '-%.0s' {2..$(NAME_LENGTH)}))
+	@printf "| %*s | %s |\n" -${NAME_LENGTH} "Name" "Version"
+	@printf "| :%s | :-----: |\n" $(NAME_SEPERATOR)
+	@for DIR_NAME in $(wildcard */); do \
+		if [ -f $$DIR_NAME/Makefile ]; then \
+			CLEANED_NAME=$$(realpath --relative-to . $$DIR_NAME); \
+			VERSION=$$(awk -F "=" '/export _VERSION = ([0-9.]+)/ {print $$2}' $$DIR_NAME/Makefile); \
+			printf "| %-$(NAME_LENGTH)s | %-$(VERSION_LENGTH)s |\n" $$CLEANED_NAME $$VERSION ; \
+		fi \
+	done
+
+# vim:tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab colorcolumn=81

--- a/README.md
+++ b/README.md
@@ -5,6 +5,33 @@ automated workflows, integrated sanity checking, and deployable everywhere.
 
 Just copy any folder you'd like to your CTF repository to start with.
 
+## Versions
+
+The following table lists the template and the latest version.
+
+| Name                           | Version |
+| :----------------------------- | :-----: |
+| flask-instanced-alpine3.19     | 1.0.0   |
+| flask-nojail-alpine3.19        | 1.0.0   |
+| offline                        | 1.0.0   |
+| php-instanced-ubuntu24.04      | 1.0.0   |
+| php-nojail-ubuntu24.04         | 1.0.0   |
+| phpxss-nojail-ubuntu24.04      | 1.0.0   |
+| pwn-jail-alpine3.19            | 1.0.0   |
+| pwn-jail-ubuntu24.04           | 1.0.0   |
+| pwn-nojail-alpine3.19          | 1.0.0   |
+| pwn-nojail-ubuntu24.04         | 1.0.0   |
+| pwn-qemu-kernel                | 1.0.0   |
+| python3.11-jail-alpine3.19     | 1.0.0   |
+| python3.11-nojail-alpine3.19   | 1.0.0   |
+| python3.12-jail-ubuntu24.04    | 1.0.0   |
+| python3.12-nojail-ubuntu24.04  | 1.0.0   |
+| rust-nojail-alpine3.19         | 1.0.0   |
+| rust-nojail-ubuntu24.04        | 1.0.0   |
+| sagemath-nojail-ubuntu22.04    | 1.0.0   |
+| solidity-nojail-debian11       | 1.0.0   |
+
+
 ## Dependencies
 
 ### Challenge Author


### PR DESCRIPTION
This PR adds a makefile and a target that generates a markdown-table listing the latest version for all templates.

Output of the command:
```bash
 $ make get_versions 
| Name                           | Version |
| :----------------------------- | :-----: |
| flask-instanced-alpine3.19     | 1.0.0   |
| flask-nojail-alpine3.19        | 1.0.0   |
| offline                        | 1.0.0   |
| php-instanced-ubuntu24.04      | 1.0.0   |
| php-nojail-ubuntu24.04         | 1.0.0   |
| phpxss-nojail-ubuntu24.04      | 1.0.0   |
| pwn-jail-alpine3.19            | 1.0.0   |
| pwn-jail-ubuntu24.04           | 1.0.0   |
| pwn-nojail-alpine3.19          | 1.0.0   |
| pwn-nojail-ubuntu24.04         | 1.0.0   |
| pwn-qemu-kernel                | 1.0.0   |
| python3.11-jail-alpine3.19     | 1.0.0   |
| python3.11-nojail-alpine3.19   | 1.0.0   |
| python3.12-jail-ubuntu24.04    | 1.0.0   |
| python3.12-nojail-ubuntu24.04  | 1.0.0   |
| rust-nojail-alpine3.19         | 1.0.0   |
| rust-nojail-ubuntu24.04        | 1.0.0   |
| sagemath-nojail-ubuntu22.04    | 1.0.0   |
| solidity-nojail-debian11       | 1.0.0   |
```

Enhances #14 