### PR TITLE
Template-type in version information

### DIFF
--- a/flask-instanced-alpine3.19/Makefile
+++ b/flask-instanced-alpine3.19/Makefile
@@ -44,7 +44,7 @@ export NAME=$(shell echo ${UNCLEAN_NAME} | tr "[:upper:]" "[:lower:]")
 # Minor: Small functionality changes w/ backward compatibility  (in sync)
 # Patch: Small fixes specific to this template                  (not in sync)
 export _VERSION = 1.0.0
-export _TEMPLATE_TYPE = flask-instanced-alpine3.19
+export _TEMPLATE = flask-instanced-alpine3.19
 
 ########################
 # Challenge Dockerfile #
@@ -210,6 +210,6 @@ clean:
 	make -C challenge clean
 
 version:
-	@echo -e "\e[1;34m[+] Template ${_TEMPLATE_TYPE} version ${_VERSION}\e[0m"
+	@echo -e "\e[1;34m[+] Template ${_TEMPLATE} version ${_VERSION}\e[0m"
 
 # vim:tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab colorcolumn=81

--- a/flask-nojail-alpine3.19/Makefile
+++ b/flask-nojail-alpine3.19/Makefile
@@ -40,7 +40,7 @@ export NAME=$(shell echo ${UNCLEAN_NAME} | tr "[:upper:]" "[:lower:]")
 # Minor: Small functionality changes w/ backward compatibility  (in sync)
 # Patch: Small fixes specific to this template                  (not in sync)
 export _VERSION = 1.0.0
-export _TEMPLATE_TYPE = flask-nojail-alpine3.19
+export _TEMPLATE = flask-nojail-alpine3.19
 
 ########################
 # Challenge Dockerfile #
@@ -199,6 +199,6 @@ clean:
 	make -C challenge clean
 
 version:
-	@echo -e "\e[1;34m[+] Template ${_TEMPLATE_TYPE} version ${_VERSION}\e[0m"
+	@echo -e "\e[1;34m[+] Template ${_TEMPLATE} version ${_VERSION}\e[0m"
 
 # vim:tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab colorcolumn=81

--- a/offline/Makefile
+++ b/offline/Makefile
@@ -40,7 +40,7 @@ export NAME=$(shell echo ${UNCLEAN_NAME} | tr "[:upper:]" "[:lower:]")
 # Minor: Small functionality changes w/ backward compatibility  (in sync)
 # Patch: Small fixes specific to this template                  (not in sync)
 export _VERSION = 1.0.0
-export _TEMPLATE_TYPE = offline
+export _TEMPLATE = offline
 
 ########################
 # Challenge Dockerfile #
@@ -165,6 +165,6 @@ clean:
 	make -C challenge clean
 
 version:
-	@echo -e "\e[1;34m[+] Template ${_TEMPLATE_TYPE} version ${_VERSION}\e[0m"
+	@echo -e "\e[1;34m[+] Template ${_TEMPLATE} version ${_VERSION}\e[0m"
 
 # vim:tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab colorcolumn=81

--- a/php-instanced-ubuntu24.04/Makefile
+++ b/php-instanced-ubuntu24.04/Makefile
@@ -44,7 +44,7 @@ export NAME=$(shell echo ${UNCLEAN_NAME} | tr "[:upper:]" "[:lower:]")
 # Minor: Small functionality changes w/ backward compatibility  (in sync)
 # Patch: Small fixes specific to this template                  (not in sync)
 export _VERSION = 1.0.0
-export _TEMPLATE_TYPE = php-instanced-ubuntu24.04
+export _TEMPLATE = php-instanced-ubuntu24.04
 
 ########################
 # Challenge Dockerfile #
@@ -210,6 +210,6 @@ clean:
 	make -C challenge clean
 
 version:
-	@echo -e "\e[1;34m[+] Template ${_TEMPLATE_TYPE} version ${_VERSION}\e[0m"
+	@echo -e "\e[1;34m[+] Template ${_TEMPLATE} version ${_VERSION}\e[0m"
 
 # vim:tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab colorcolumn=81

--- a/php-nojail-ubuntu24.04/Makefile
+++ b/php-nojail-ubuntu24.04/Makefile
@@ -40,7 +40,7 @@ export NAME=$(shell echo ${UNCLEAN_NAME} | tr "[:upper:]" "[:lower:]")
 # Minor: Small functionality changes w/ backward compatibility  (in sync)
 # Patch: Small fixes specific to this template                  (not in sync)
 export _VERSION = 1.0.0
-export _TEMPLATE_TYPE = php-nojail-ubuntu24.04
+export _TEMPLATE = php-nojail-ubuntu24.04
 
 ########################
 # Challenge Dockerfile #
@@ -199,6 +199,6 @@ clean:
 	make -C challenge clean
 
 version:
-	@echo -e "\e[1;34m[+] Template ${_TEMPLATE_TYPE} version ${_VERSION}\e[0m"
+	@echo -e "\e[1;34m[+] Template ${_TEMPLATE} version ${_VERSION}\e[0m"
 
 # vim:tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab colorcolumn=81

--- a/phpxss-nojail-ubuntu24.04/Makefile
+++ b/phpxss-nojail-ubuntu24.04/Makefile
@@ -40,7 +40,7 @@ export NAME=$(shell echo ${UNCLEAN_NAME} | tr "[:upper:]" "[:lower:]")
 # Minor: Small functionality changes w/ backward compatibility  (in sync)
 # Patch: Small fixes specific to this template                  (not in sync)
 export _VERSION = 1.0.0
-export _TEMPLATE_TYPE = phpxss-nojail-ubuntu24.04
+export _TEMPLATE = phpxss-nojail-ubuntu24.04
 
 ########################
 # Challenge Dockerfile #
@@ -199,6 +199,6 @@ clean:
 	make -C challenge clean
 
 version:
-	@echo -e "\e[1;34m[+] Template ${_TEMPLATE_TYPE} version ${_VERSION}\e[0m"
+	@echo -e "\e[1;34m[+] Template ${_TEMPLATE} version ${_VERSION}\e[0m"
 
 # vim:tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab colorcolumn=81

--- a/pwn-jail-alpine3.19/Makefile
+++ b/pwn-jail-alpine3.19/Makefile
@@ -40,7 +40,7 @@ export NAME=$(shell echo ${UNCLEAN_NAME} | tr "[:upper:]" "[:lower:]")
 # Minor: Small functionality changes w/ backward compatibility  (in sync)
 # Patch: Small fixes specific to this template                  (not in sync)
 export _VERSION = 1.0.0
-export _TEMPLATE_TYPE = pwn-jail-alpine3.19
+export _TEMPLATE = pwn-jail-alpine3.19
 
 ########################
 # Challenge Dockerfile #
@@ -200,6 +200,6 @@ clean:
 	make -C challenge clean
 
 version:
-	@echo -e "\e[1;34m[+] Template ${_TEMPLATE_TYPE} version ${_VERSION}\e[0m"
+	@echo -e "\e[1;34m[+] Template ${_TEMPLATE} version ${_VERSION}\e[0m"
 
 # vim:tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab colorcolumn=81

--- a/pwn-jail-ubuntu24.04/Makefile
+++ b/pwn-jail-ubuntu24.04/Makefile
@@ -40,7 +40,7 @@ export NAME=$(shell echo ${UNCLEAN_NAME} | tr "[:upper:]" "[:lower:]")
 # Minor: Small functionality changes w/ backward compatibility  (in sync)
 # Patch: Small fixes specific to this template                  (not in sync)
 export _VERSION = 1.0.0
-export _TEMPLATE_TYPE = pwn-jail-ubuntu24.04
+export _TEMPLATE = pwn-jail-ubuntu24.04
 
 ########################
 # Challenge Dockerfile #
@@ -200,6 +200,6 @@ clean:
 	make -C challenge clean
 
 version:
-	@echo -e "\e[1;34m[+] Template ${_TEMPLATE_TYPE} version ${_VERSION}\e[0m"
+	@echo -e "\e[1;34m[+] Template ${_TEMPLATE} version ${_VERSION}\e[0m"
 
 # vim:tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab colorcolumn=81

--- a/pwn-nojail-alpine3.19/Makefile
+++ b/pwn-nojail-alpine3.19/Makefile
@@ -40,7 +40,7 @@ export NAME=$(shell echo ${UNCLEAN_NAME} | tr "[:upper:]" "[:lower:]")
 # Minor: Small functionality changes w/ backward compatibility  (in sync)
 # Patch: Small fixes specific to this template                  (not in sync)
 export _VERSION = 1.0.0
-export _TEMPLATE_TYPE = pwn-nojail-alpine3.19
+export _TEMPLATE = pwn-nojail-alpine3.19
 
 ########################
 # Challenge Dockerfile #
@@ -200,6 +200,6 @@ clean:
 	make -C challenge clean
 
 version:
-	@echo -e "\e[1;34m[+] Template ${_TEMPLATE_TYPE} version ${_VERSION}\e[0m"
+	@echo -e "\e[1;34m[+] Template ${_TEMPLATE} version ${_VERSION}\e[0m"
 
 # vim:tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab colorcolumn=81

--- a/pwn-nojail-ubuntu24.04/Makefile
+++ b/pwn-nojail-ubuntu24.04/Makefile
@@ -40,7 +40,7 @@ export NAME=$(shell echo ${UNCLEAN_NAME} | tr "[:upper:]" "[:lower:]")
 # Minor: Small functionality changes w/ backward compatibility  (in sync)
 # Patch: Small fixes specific to this template                  (not in sync)
 export _VERSION = 1.0.0
-export _TEMPLATE_TYPE = pwn-nojail-ubuntu24.04
+export _TEMPLATE = pwn-nojail-ubuntu24.04
 
 ########################
 # Challenge Dockerfile #
@@ -200,6 +200,6 @@ clean:
 	make -C challenge clean
 
 version:
-	@echo -e "\e[1;34m[+] Template ${_TEMPLATE_TYPE} version ${_VERSION}\e[0m"
+	@echo -e "\e[1;34m[+] Template ${_TEMPLATE} version ${_VERSION}\e[0m"
 
 # vim:tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab colorcolumn=81

--- a/pwn-qemu-kernel/Makefile
+++ b/pwn-qemu-kernel/Makefile
@@ -44,7 +44,7 @@ export NAME=$(shell echo ${UNCLEAN_NAME} | tr "[:upper:]" "[:lower:]")
 # Minor: Small functionality changes w/ backward compatibility  (in sync)
 # Patch: Small fixes specific to this template                  (not in sync)
 export _VERSION = 1.0.0
-export _TEMPLATE_TYPE = pwn-qemu-kernel
+export _TEMPLATE = pwn-qemu-kernel
 
 ########################
 # Challenge Dockerfile #
@@ -206,6 +206,6 @@ clean:
 	make -C challenge clean
 
 version:
-	@echo -e "\e[1;34m[+] Template ${_TEMPLATE_TYPE} version ${_VERSION}\e[0m"
+	@echo -e "\e[1;34m[+] Template ${_TEMPLATE} version ${_VERSION}\e[0m"
 
 # vim:tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab colorcolumn=81

--- a/python3.11-jail-alpine3.19/Makefile
+++ b/python3.11-jail-alpine3.19/Makefile
@@ -40,7 +40,7 @@ export NAME=$(shell echo ${UNCLEAN_NAME} | tr "[:upper:]" "[:lower:]")
 # Minor: Small functionality changes w/ backward compatibility  (in sync)
 # Patch: Small fixes specific to this template                  (not in sync)
 export _VERSION = 1.0.0
-export _TEMPLATE_TYPE = python3.11-jail-alpine3.19
+export _TEMPLATE = python3.11-jail-alpine3.19
 
 ########################
 # Challenge Dockerfile #
@@ -200,6 +200,6 @@ clean:
 	make -C challenge clean
 
 version:
-	@echo -e "\e[1;34m[+] Template ${_TEMPLATE_TYPE} version ${_VERSION}\e[0m"
+	@echo -e "\e[1;34m[+] Template ${_TEMPLATE} version ${_VERSION}\e[0m"
 
 # vim:tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab colorcolumn=81

--- a/python3.11-nojail-alpine3.19/Makefile
+++ b/python3.11-nojail-alpine3.19/Makefile
@@ -40,7 +40,7 @@ export NAME=$(shell echo ${UNCLEAN_NAME} | tr "[:upper:]" "[:lower:]")
 # Minor: Small functionality changes w/ backward compatibility  (in sync)
 # Patch: Small fixes specific to this template                  (not in sync)
 export _VERSION = 1.0.0
-export _TEMPLATE_TYPE = python3.11-nojail-alpine3.19
+export _TEMPLATE = python3.11-nojail-alpine3.19
 
 ########################
 # Challenge Dockerfile #
@@ -200,6 +200,6 @@ clean:
 	make -C challenge clean
 
 version:
-	@echo -e "\e[1;34m[+] Template ${_TEMPLATE_TYPE} version ${_VERSION}\e[0m"
+	@echo -e "\e[1;34m[+] Template ${_TEMPLATE} version ${_VERSION}\e[0m"
 
 # vim:tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab colorcolumn=81

--- a/python3.12-jail-ubuntu24.04/Makefile
+++ b/python3.12-jail-ubuntu24.04/Makefile
@@ -40,7 +40,7 @@ export NAME=$(shell echo ${UNCLEAN_NAME} | tr "[:upper:]" "[:lower:]")
 # Minor: Small functionality changes w/ backward compatibility  (in sync)
 # Patch: Small fixes specific to this template                  (not in sync)
 export _VERSION = 1.0.0
-export _TEMPLATE_TYPE = python3.12-jail-ubuntu24.04
+export _TEMPLATE = python3.12-jail-ubuntu24.04
 
 ########################
 # Challenge Dockerfile #
@@ -200,6 +200,6 @@ clean:
 	make -C challenge clean
 
 version:
-	@echo -e "\e[1;34m[+] Template ${_TEMPLATE_TYPE} version ${_VERSION}\e[0m"
+	@echo -e "\e[1;34m[+] Template ${_TEMPLATE} version ${_VERSION}\e[0m"
 
 # vim:tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab colorcolumn=81

--- a/python3.12-nojail-ubuntu24.04/Makefile
+++ b/python3.12-nojail-ubuntu24.04/Makefile
@@ -40,7 +40,7 @@ export NAME=$(shell echo ${UNCLEAN_NAME} | tr "[:upper:]" "[:lower:]")
 # Minor: Small functionality changes w/ backward compatibility  (in sync)
 # Patch: Small fixes specific to this template                  (not in sync)
 export _VERSION = 1.0.0
-export _TEMPLATE_TYPE = python3.12-nojail-ubuntu24.04
+export _TEMPLATE = python3.12-nojail-ubuntu24.04
 
 ########################
 # Challenge Dockerfile #
@@ -200,6 +200,6 @@ clean:
 	make -C challenge clean
 
 version:
-	@echo -e "\e[1;34m[+] Template ${_TEMPLATE_TYPE} version ${_VERSION}\e[0m"
+	@echo -e "\e[1;34m[+] Template ${_TEMPLATE} version ${_VERSION}\e[0m"
 
 # vim:tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab colorcolumn=81

--- a/rust-nojail-alpine3.19/Makefile
+++ b/rust-nojail-alpine3.19/Makefile
@@ -40,7 +40,7 @@ export NAME=$(shell echo ${UNCLEAN_NAME} | tr "[:upper:]" "[:lower:]")
 # Minor: Small functionality changes w/ backward compatibility  (in sync)
 # Patch: Small fixes specific to this template                  (not in sync)
 export _VERSION = 1.0.0
-export _TEMPLATE_TYPE = rust-nojail-alpine3.19
+export _TEMPLATE = rust-nojail-alpine3.19
 
 ########################
 # Challenge Dockerfile #
@@ -200,6 +200,6 @@ clean:
 	make -C challenge clean
 
 version:
-	@echo -e "\e[1;34m[+] Template ${_TEMPLATE_TYPE} version ${_VERSION}\e[0m"
+	@echo -e "\e[1;34m[+] Template ${_TEMPLATE} version ${_VERSION}\e[0m"
 
 # vim:tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab colorcolumn=81

--- a/rust-nojail-ubuntu24.04/Makefile
+++ b/rust-nojail-ubuntu24.04/Makefile
@@ -40,7 +40,7 @@ export NAME=$(shell echo ${UNCLEAN_NAME} | tr "[:upper:]" "[:lower:]")
 # Minor: Small functionality changes w/ backward compatibility  (in sync)
 # Patch: Small fixes specific to this template                  (not in sync)
 export _VERSION = 1.0.0
-export _TEMPLATE_TYPE = rust-nojail-ubuntu24.04
+export _TEMPLATE = rust-nojail-ubuntu24.04
 
 ########################
 # Challenge Dockerfile #
@@ -200,6 +200,6 @@ clean:
 	make -C challenge clean
 
 version:
-	@echo -e "\e[1;34m[+] Template ${_TEMPLATE_TYPE} version ${_VERSION}\e[0m"
+	@echo -e "\e[1;34m[+] Template ${_TEMPLATE} version ${_VERSION}\e[0m"
 
 # vim:tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab colorcolumn=81

--- a/sagemath-nojail-ubuntu22.04/Makefile
+++ b/sagemath-nojail-ubuntu22.04/Makefile
@@ -40,7 +40,7 @@ export NAME=$(shell echo ${UNCLEAN_NAME} | tr "[:upper:]" "[:lower:]")
 # Minor: Small functionality changes w/ backward compatibility  (in sync)
 # Patch: Small fixes specific to this template                  (not in sync)
 export _VERSION = 1.0.0
-export _TEMPLATE_TYPE = sagemath-nojail-ubuntu22.04
+export _TEMPLATE = sagemath-nojail-ubuntu22.04
 
 ########################
 # Challenge Dockerfile #
@@ -200,6 +200,6 @@ clean:
 	make -C challenge clean
 
 version:
-	@echo -e "\e[1;34m[+] Template ${_TEMPLATE_TYPE} version ${_VERSION}\e[0m"
+	@echo -e "\e[1;34m[+] Template ${_TEMPLATE} version ${_VERSION}\e[0m"
 
 # vim:tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab colorcolumn=81

--- a/solidity-nojail-debian11/Makefile
+++ b/solidity-nojail-debian11/Makefile
@@ -48,7 +48,7 @@ export NAME=$(shell echo ${UNCLEAN_NAME} | tr "[:upper:]" "[:lower:]")
 # Minor: Small functionality changes w/ backward compatibility  (in sync)
 # Patch: Small fixes specific to this template                  (not in sync)
 export _VERSION = 1.0.0
-export _TEMPLATE_TYPE = solidity-nojail-debian11
+export _TEMPLATE = solidity-nojail-debian11
 
 ########################
 # Challenge Dockerfile #
@@ -212,6 +212,6 @@ clean:
 	make -C challenge clean
 
 version:
-	@echo -e "\e[1;34m[+] Template ${_TEMPLATE_TYPE} version ${_VERSION}\e[0m"
+	@echo -e "\e[1;34m[+] Template ${_TEMPLATE} version ${_VERSION}\e[0m"
 
 # vim:tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab colorcolumn=81


### PR DESCRIPTION
Currently the folder name is the easiest way to identify the template being used. However, once you rename the folder, the only way to identify it is by comparing the implemented make-targets and the dockerfiles being used.

This PR adds a new variable that stores the template name (as we can't rely on the name of the parent folder)