### PR TITLE
Implementing make patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,37 +15,17 @@ get_versions:
 		fi \
 	done
 
-export FOUND_DIFF=0
-export FOUND_DIFF_CONTENT=
+PATCH:=./name.patch
 patch:
-	@for DIR_NAME in $(wildcard */); do \
-		if [ -f $$DIR_NAME/Makefile ]; then \
-			DIFF=$$(git diff $$DIR_NAME); \
-			if [ ! -z "$$DIFF" ]; then \
-				echo -e "\e[1;34m[+] Found diff in $$DIR_NAME\e[0m"; \
-				if [ "$$FOUND_DIFF" == "0" ]; then \
-					FOUND_DIFF="$$DIR_NAME"; \
-					FOUND_DIFF_CONTENT="$$DIFF"; \
-				else \
-					echo -e "\e[1;33m[+] Cannot have changes in two templates! ABORT\e[0m"; \
-					exit 1; \
+	@if [ -f ${PATCH} ]; then \
+		for f in $(wildcard */) ; do \
+				if [[ -d "$$f" && -f "$$f/Makefile" ]]; then \
+					 echo -e "\e[1;34m[+] Patching $f with ${PATCH}\e[0m"; \
+					patch -d $$f --backup-if-mismatch -p2 < ${PATCH}; \
 				fi \
-			fi \
-		fi \
-	done; \
-	if [ "$$FOUND_DIFF" == "0" ]; then \
-		echo -e "\e[1;34m[+] No changes detected\e[0m"; \
-		exit 0; \
-	fi; \
-	for DIR_NAME in $(wildcard */); do \
-		if [ -f $$DIR_NAME/Makefile ]; then \
-			if [ "$$DIR_NAME" == "$$FOUND_DIFF" ]; then \
-				echo -e "\e[1;34m[+] Skipping $$DIR_NAME due to it is the source of the patch\e[0m"; \
-			else \
-				echo -e "\e[1;34m[+] Patching $$DIR_NAME\e[0m"; \
-				echo "$$FOUND_DIFF_CONTENT" | patch -d $$DIR_NAME --backup-if-mismatch -p2; \
-			fi \
-		fi \
-	done;
+		done \
+	else \
+		echo -e "\e[1;31m[+] ${PATCH} file does not exist"; \
+	fi
 
 # vim:tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab colorcolumn=81


### PR DESCRIPTION
#49 Implements `make patch` in the root `Makefile`.

The target has the following functionality:
- Searches in the templates for a change
- Applies this changes to all other templates
- IF there are changes in several templates, then the script aborts

---

TIL:
```sh
a="hello
world"

echo $a
echo "$a"
```

The first echo statement omits the newline, while the second echo keeps the newline.