### PR TITLE
Fixed SRARGS for solidity

### DIFF
--- a/solidity-nojail-debian11/Makefile
+++ b/solidity-nojail-debian11/Makefile
@@ -149,8 +149,7 @@ TICKETS:= $(shell shuf -n ${TIMES} solution/tickets.txt | tr "\n" " ")
 srun-sequential:
 	@echo -e "\e[1;34m[+] Running Sequential Container against" \
 		"${HOST}:${PORT}\e[0m"
-	parallel --jobs 1 docker run --rm \
-		--hostname localhost --net=host --platform linux/amd64 \
+	parallel --jobs 1 docker run --rm ${SRARGS} \
 		${REGISTRY}/${NAME}-solvescript \
 		/usr/bin/timeout -k 5 ${TIMEOUT} python solve_challenge.py \
 			--host ${HOST} --port ${PORT} --ticket $1 \
@@ -160,8 +159,7 @@ JOBS=2
 srun-parallel:
 	@echo -e "\e[1;34m[+] Running Parallel Container against ${HOST}:${PORT}\e[0m"
 	cd solution/ ; \
-	parallel --jobs ${JOBS} docker run --rm \
-		--hostname localhost --net=host --platform linux/amd64 \
+	parallel --jobs ${JOBS} docker run --rm ${SRARGS} \
 		${REGISTRY}/${NAME}-solvescript \
 		/usr/bin/timeout -k 5 ${TIMEOUT} python solve_challenge.py \
 			--host ${HOST} --port ${PORT} --ticket $1 \


### PR DESCRIPTION
`srun-sequential` and `srun-parallel` have not used `SRARGS`. However, because we need to operate on different blockchains, we need a different (valid) ticket each time we execute the solve-script.

Currently, the host, port and ticket are passed via arguments to the solve-script, but it should be possible to remove this as well. I'll look into it.

Closes #35 