### PR TITLE
[Solidity] Updated foundry version

### DIFF
--- a/solidity-nojail-debian11/Dockerfile
+++ b/solidity-nojail-debian11/Dockerfile
@@ -49,7 +49,7 @@ RUN curl -L https://foundry.paradigm.xyz | bash \
     && bash -c "\
         source /root/.bashrc \
         && foundryup \
-            --install stable \
+            --install v1.0.0 \
             --arch amd64" \
     && chmod 755 -R /root
 

--- a/solidity-nojail-debian11/solution/Dockerfile
+++ b/solidity-nojail-debian11/solution/Dockerfile
@@ -17,7 +17,7 @@ RUN curl -L https://foundry.paradigm.xyz | bash \
     && bash -c "\
         source /root/.bashrc \
         && foundryup \
-            --install stable \
+            --install v1.0.0 \
             --arch amd64" \
     && chmod 755 -R /root
 


### PR DESCRIPTION
Wasn't able to install the nightly version what we have used previously, therefor I opted to switch to the stable version.
I am not a fan of it because pinning the version would be nice (even if it is a pin to a nightly version).