### PR TITLE
Added documentation for the make-targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ with `make version`.
 
 ## Dependencies
 
-### Authors
+### Challenge Author
 
 Install `docker`, `bash`, `make`, GNU `envsubst`, GNU `tar`, GNU `coreutils`
 and `parallel`.


### PR DESCRIPTION
As requested by some members, this PR adds a documentation for the make-targets.
I tried to highlight a few oddities that may be important to the authors (e.g. the way the challenge is being built in case of a binary) 

Closes #27 