### PR TITLE
Converting to dash compatible syntax

### DIFF
--- a/bash-jail-ubuntu24.04/Makefile
+++ b/bash-jail-ubuntu24.04/Makefile
@@ -149,7 +149,7 @@ srun-sequential:
 	cd solution/ ; \
 	parallel --jobs 1 docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-sequential-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 	
 JOBS=2
 srun-parallel:
@@ -157,7 +157,7 @@ srun-parallel:
 	cd solution/ ; \
 	parallel --jobs ${JOBS} docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-parallel-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 
 skill:
 	@echo -e "\e[1;34m[+] Killing Solution Container/s\e[0m"

--- a/bash-nojail-ubuntu24.04/Makefile
+++ b/bash-nojail-ubuntu24.04/Makefile
@@ -149,7 +149,7 @@ srun-sequential:
 	cd solution/ ; \
 	parallel --jobs 1 docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-sequential-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 	
 JOBS=2
 srun-parallel:
@@ -157,7 +157,7 @@ srun-parallel:
 	cd solution/ ; \
 	parallel --jobs ${JOBS} docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-parallel-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 
 skill:
 	@echo -e "\e[1;34m[+] Killing Solution Container/s\e[0m"

--- a/flask-instanced-alpine3.19/Makefile
+++ b/flask-instanced-alpine3.19/Makefile
@@ -159,7 +159,7 @@ srun-sequential:
 	cd solution/ ; \
 	parallel --jobs 1 docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-sequential-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 	
 JOBS=2
 srun-parallel:
@@ -167,7 +167,7 @@ srun-parallel:
 	cd solution/ ; \
 	parallel --jobs ${JOBS} docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-parallel-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 
 skill:
 	@echo -e "\e[1;34m[+] Killing Solution Container/s\e[0m"

--- a/flask-nojail-alpine3.19/Makefile
+++ b/flask-nojail-alpine3.19/Makefile
@@ -148,7 +148,7 @@ srun-sequential:
 	cd solution/ ; \
 	parallel --jobs 1 docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-sequential-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 	
 JOBS=2
 srun-parallel:
@@ -156,7 +156,7 @@ srun-parallel:
 	cd solution/ ; \
 	parallel --jobs ${JOBS} docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-parallel-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 
 skill:
 	@echo -e "\e[1;34m[+] Killing Solution Container/s\e[0m"

--- a/php-instanced-ubuntu24.04/Makefile
+++ b/php-instanced-ubuntu24.04/Makefile
@@ -159,7 +159,7 @@ srun-sequential:
 	cd solution/ ; \
 	parallel --jobs 1 docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-sequential-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 	
 JOBS=2
 srun-parallel:
@@ -167,7 +167,7 @@ srun-parallel:
 	cd solution/ ; \
 	parallel --jobs ${JOBS} docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-parallel-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 
 skill:
 	@echo -e "\e[1;34m[+] Killing Solution Container/s\e[0m"

--- a/php-nojail-ubuntu24.04/Makefile
+++ b/php-nojail-ubuntu24.04/Makefile
@@ -148,7 +148,7 @@ srun-sequential:
 	cd solution/ ; \
 	parallel --jobs 1 docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-sequential-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 	
 JOBS=2
 srun-parallel:
@@ -156,7 +156,7 @@ srun-parallel:
 	cd solution/ ; \
 	parallel --jobs ${JOBS} docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-parallel-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 
 skill:
 	@echo -e "\e[1;34m[+] Killing Solution Container/s\e[0m"

--- a/phpxss-nojail-ubuntu24.04/Makefile
+++ b/phpxss-nojail-ubuntu24.04/Makefile
@@ -148,7 +148,7 @@ srun-sequential:
 	cd solution/ ; \
 	parallel --jobs 1 docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-sequential-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 	
 JOBS=2
 srun-parallel:
@@ -156,7 +156,7 @@ srun-parallel:
 	cd solution/ ; \
 	parallel --jobs ${JOBS} docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-parallel-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 
 skill:
 	@echo -e "\e[1;34m[+] Killing Solution Container/s\e[0m"

--- a/pwn-jail-alpine3.19/Makefile
+++ b/pwn-jail-alpine3.19/Makefile
@@ -149,7 +149,7 @@ srun-sequential:
 	cd solution/ ; \
 	parallel --jobs 1 docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-sequential-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 	
 JOBS=2
 srun-parallel:
@@ -157,7 +157,7 @@ srun-parallel:
 	cd solution/ ; \
 	parallel --jobs ${JOBS} docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-parallel-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 
 skill:
 	@echo -e "\e[1;34m[+] Killing Solution Container/s\e[0m"

--- a/pwn-jail-ubuntu24.04/Makefile
+++ b/pwn-jail-ubuntu24.04/Makefile
@@ -149,7 +149,7 @@ srun-sequential:
 	cd solution/ ; \
 	parallel --jobs 1 docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-sequential-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 	
 JOBS=2
 srun-parallel:
@@ -157,7 +157,7 @@ srun-parallel:
 	cd solution/ ; \
 	parallel --jobs ${JOBS} docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-parallel-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 
 skill:
 	@echo -e "\e[1;34m[+] Killing Solution Container/s\e[0m"

--- a/pwn-nojail-alpine3.19/Makefile
+++ b/pwn-nojail-alpine3.19/Makefile
@@ -149,7 +149,7 @@ srun-sequential:
 	cd solution/ ; \
 	parallel --jobs 1 docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-sequential-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 	
 JOBS=2
 srun-parallel:
@@ -157,7 +157,7 @@ srun-parallel:
 	cd solution/ ; \
 	parallel --jobs ${JOBS} docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-parallel-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 
 skill:
 	@echo -e "\e[1;34m[+] Killing Solution Container/s\e[0m"

--- a/pwn-nojail-ubuntu24.04/Makefile
+++ b/pwn-nojail-ubuntu24.04/Makefile
@@ -149,7 +149,7 @@ srun-sequential:
 	cd solution/ ; \
 	parallel --jobs 1 docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-sequential-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 	
 JOBS=2
 srun-parallel:
@@ -157,7 +157,7 @@ srun-parallel:
 	cd solution/ ; \
 	parallel --jobs ${JOBS} docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-parallel-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 
 skill:
 	@echo -e "\e[1;34m[+] Killing Solution Container/s\e[0m"

--- a/pwn-qemu-kernel/Makefile
+++ b/pwn-qemu-kernel/Makefile
@@ -155,7 +155,7 @@ srun-sequential:
 	cd solution/ ; \
 	parallel --jobs 1 docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-sequential-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 	
 JOBS=2
 srun-parallel:
@@ -163,7 +163,7 @@ srun-parallel:
 	cd solution/ ; \
 	parallel --jobs ${JOBS} docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-parallel-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 
 skill:
 	@echo -e "\e[1;34m[+] Killing Solution Container/s\e[0m"

--- a/python3.11-jail-alpine3.19/Makefile
+++ b/python3.11-jail-alpine3.19/Makefile
@@ -149,7 +149,7 @@ srun-sequential:
 	cd solution/ ; \
 	parallel --jobs 1 docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-sequential-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 	
 JOBS=2
 srun-parallel:
@@ -157,7 +157,7 @@ srun-parallel:
 	cd solution/ ; \
 	parallel --jobs ${JOBS} docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-parallel-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 
 skill:
 	@echo -e "\e[1;34m[+] Killing Solution Container/s\e[0m"

--- a/python3.11-nojail-alpine3.19/Makefile
+++ b/python3.11-nojail-alpine3.19/Makefile
@@ -149,7 +149,7 @@ srun-sequential:
 	cd solution/ ; \
 	parallel --jobs 1 docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-sequential-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 	
 JOBS=2
 srun-parallel:
@@ -157,7 +157,7 @@ srun-parallel:
 	cd solution/ ; \
 	parallel --jobs ${JOBS} docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-parallel-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 
 skill:
 	@echo -e "\e[1;34m[+] Killing Solution Container/s\e[0m"

--- a/python3.12-jail-ubuntu24.04/Makefile
+++ b/python3.12-jail-ubuntu24.04/Makefile
@@ -149,7 +149,7 @@ srun-sequential:
 	cd solution/ ; \
 	parallel --jobs 1 docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-sequential-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 	
 JOBS=2
 srun-parallel:
@@ -157,7 +157,7 @@ srun-parallel:
 	cd solution/ ; \
 	parallel --jobs ${JOBS} docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-parallel-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 
 skill:
 	@echo -e "\e[1;34m[+] Killing Solution Container/s\e[0m"

--- a/python3.12-nojail-ubuntu24.04/Makefile
+++ b/python3.12-nojail-ubuntu24.04/Makefile
@@ -149,7 +149,7 @@ srun-sequential:
 	cd solution/ ; \
 	parallel --jobs 1 docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-sequential-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 	
 JOBS=2
 srun-parallel:
@@ -157,7 +157,7 @@ srun-parallel:
 	cd solution/ ; \
 	parallel --jobs ${JOBS} docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-parallel-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 
 skill:
 	@echo -e "\e[1;34m[+] Killing Solution Container/s\e[0m"

--- a/rust-nojail-alpine3.19/Makefile
+++ b/rust-nojail-alpine3.19/Makefile
@@ -149,7 +149,7 @@ srun-sequential:
 	cd solution/ ; \
 	parallel --jobs 1 docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-sequential-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 	
 JOBS=2
 srun-parallel:
@@ -157,7 +157,7 @@ srun-parallel:
 	cd solution/ ; \
 	parallel --jobs ${JOBS} docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-parallel-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 
 skill:
 	@echo -e "\e[1;34m[+] Killing Solution Container/s\e[0m"

--- a/rust-nojail-ubuntu24.04/Makefile
+++ b/rust-nojail-ubuntu24.04/Makefile
@@ -149,7 +149,7 @@ srun-sequential:
 	cd solution/ ; \
 	parallel --jobs 1 docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-sequential-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 	
 JOBS=2
 srun-parallel:
@@ -157,7 +157,7 @@ srun-parallel:
 	cd solution/ ; \
 	parallel --jobs ${JOBS} docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-parallel-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 
 skill:
 	@echo -e "\e[1;34m[+] Killing Solution Container/s\e[0m"

--- a/sagemath-nojail-ubuntu22.04/Makefile
+++ b/sagemath-nojail-ubuntu22.04/Makefile
@@ -149,7 +149,7 @@ srun-sequential:
 	cd solution/ ; \
 	parallel --jobs 1 docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-sequential-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 	
 JOBS=2
 srun-parallel:
@@ -157,7 +157,7 @@ srun-parallel:
 	cd solution/ ; \
 	parallel --jobs ${JOBS} docker run --rm ${SRARGS} \
 		--name ${NAME}-solvescript-parallel-{} ${REGISTRY}/${NAME}-solvescript \
-		::: {1..${TIMES}}
+		::: `seq -s' ' 1 1 ${TIMES}`
 
 skill:
 	@echo -e "\e[1;34m[+] Killing Solution Container/s\e[0m"


### PR DESCRIPTION
This PR addresses #1.
We have seen that for some distributions like Ubuntu, `make` uses `dash` as underlying shell raising errors in `srun-sequential` and `srun-parallel`. This is due to the fact, that the syntax `{1..5}` is a `bash` specific feature.
Therefore, I use `seq` instead which is packed in `coreutils`