### PR TITLE
default target LOCAL and specify REMOTE in Dockerfile

### DIFF
--- a/bash-jail-ubuntu24.04/solution/Dockerfile
+++ b/bash-jail-ubuntu24.04/solution/Dockerfile
@@ -21,4 +21,4 @@ USER pwntools
 
 ENV PWNLIB_NOTERM=1
 
-CMD /usr/bin/timeout -k 5 ${TIMEOUT} ./exploit HOST=${HOST} PORT=${PORT}
+CMD /usr/bin/timeout -k 5 ${TIMEOUT} ./exploit REMOTE HOST=${HOST} PORT=${PORT}

--- a/bash-jail-ubuntu24.04/solution/exploit
+++ b/bash-jail-ubuntu24.04/solution/exploit
@@ -60,10 +60,11 @@ def start_remote(argv=[], *a, **kw):
 
 def start(argv=[], *a, **kw):
     '''Start the exploit against the target.'''
-    if args.LOCAL:
-        return start_local(argv, *a, **kw)
-    else:
+    if args.REMOTE:
         return start_remote(argv, *a, **kw)
+    else:
+        return start_local(argv, *a, **kw)
+
 
 # Specify your GDB script here for debugging
 # GDB will be launched if the exploit is run via e.g.

--- a/bash-nojail-ubuntu24.04/solution/Dockerfile
+++ b/bash-nojail-ubuntu24.04/solution/Dockerfile
@@ -21,4 +21,4 @@ USER pwntools
 
 ENV PWNLIB_NOTERM=1
 
-CMD /usr/bin/timeout -k 5 ${TIMEOUT} ./exploit HOST=${HOST} PORT=${PORT}
+CMD /usr/bin/timeout -k 5 ${TIMEOUT} ./exploit REMOTE HOST=${HOST} PORT=${PORT}

--- a/bash-nojail-ubuntu24.04/solution/exploit
+++ b/bash-nojail-ubuntu24.04/solution/exploit
@@ -59,10 +59,11 @@ def start_remote(argv=[], *a, **kw):
 
 def start(argv=[], *a, **kw):
     '''Start the exploit against the target.'''
-    if args.LOCAL:
-        return start_local(argv, *a, **kw)
-    else:
+    if args.REMOTE:
         return start_remote(argv, *a, **kw)
+    else:
+        return start_local(argv, *a, **kw)
+
 
 # Specify your GDB script here for debugging
 # GDB will be launched if the exploit is run via e.g.

--- a/offline/solution/Dockerfile
+++ b/offline/solution/Dockerfile
@@ -23,4 +23,4 @@ COPY ./encrypted.b64 /app/
 
 ENV PWNLIB_NOTERM=1
 
-CMD /usr/bin/timeout -k 5 ${TIMEOUT} ./exploit HOST=${HOST} PORT=${PORT}
+CMD /usr/bin/timeout -k 5 ${TIMEOUT} ./exploit REMOTE HOST=${HOST} PORT=${PORT}

--- a/offline/solution/exploit
+++ b/offline/solution/exploit
@@ -60,10 +60,11 @@ def start_remote(argv=[], *a, **kw):
 
 def start(argv=[], *a, **kw):
     '''Start the exploit against the target.'''
-    if args.LOCAL:
-        return start_local(argv, *a, **kw)
-    else:
+    if args.REMOTE:
         return start_remote(argv, *a, **kw)
+    else:
+        return start_local(argv, *a, **kw)
+
 
 # Specify your GDB script here for debugging
 # GDB will be launched if the exploit is run via e.g.

--- a/pwn-jail-alpine3.19/solution/Dockerfile
+++ b/pwn-jail-alpine3.19/solution/Dockerfile
@@ -23,4 +23,4 @@ COPY challenge .
 
 ENV PWNLIB_NOTERM=1
 
-CMD /usr/bin/timeout -k 5 ${TIMEOUT} ./exploit HOST=${HOST} PORT=${PORT}
+CMD /usr/bin/timeout -k 5 ${TIMEOUT} ./exploit REMOTE HOST=${HOST} PORT=${PORT}

--- a/pwn-jail-alpine3.19/solution/exploit
+++ b/pwn-jail-alpine3.19/solution/exploit
@@ -65,10 +65,11 @@ def start_remote(argv=[], *a, **kw):
 
 def start(argv=[], *a, **kw):
     '''Start the exploit against the target.'''
-    if args.LOCAL:
-        return start_local(argv, *a, **kw)
-    else:
+    if args.REMOTE:
         return start_remote(argv, *a, **kw)
+    else:
+        return start_local(argv, *a, **kw)
+
 
 # Specify your GDB script here for debugging
 # GDB will be launched if the exploit is run via e.g.

--- a/pwn-jail-ubuntu24.04/solution/Dockerfile
+++ b/pwn-jail-ubuntu24.04/solution/Dockerfile
@@ -23,4 +23,4 @@ COPY challenge .
 
 ENV PWNLIB_NOTERM=1
 
-CMD /usr/bin/timeout -k 5 ${TIMEOUT} ./exploit HOST=${HOST} PORT=${PORT}
+CMD /usr/bin/timeout -k 5 ${TIMEOUT} ./exploit REMOTE HOST=${HOST} PORT=${PORT}

--- a/pwn-jail-ubuntu24.04/solution/exploit
+++ b/pwn-jail-ubuntu24.04/solution/exploit
@@ -65,10 +65,11 @@ def start_remote(argv=[], *a, **kw):
 
 def start(argv=[], *a, **kw):
     '''Start the exploit against the target.'''
-    if args.LOCAL:
-        return start_local(argv, *a, **kw)
-    else:
+    if args.REMOTE:
         return start_remote(argv, *a, **kw)
+    else:
+        return start_local(argv, *a, **kw)
+
 
 # Specify your GDB script here for debugging
 # GDB will be launched if the exploit is run via e.g.

--- a/pwn-nojail-alpine3.19/solution/Dockerfile
+++ b/pwn-nojail-alpine3.19/solution/Dockerfile
@@ -23,4 +23,4 @@ COPY challenge .
 
 ENV PWNLIB_NOTERM=1
 
-CMD /usr/bin/timeout -k 5 ${TIMEOUT} ./exploit HOST=${HOST} PORT=${PORT}
+CMD /usr/bin/timeout -k 5 ${TIMEOUT} ./exploit REMOTE HOST=${HOST} PORT=${PORT}

--- a/pwn-nojail-alpine3.19/solution/exploit
+++ b/pwn-nojail-alpine3.19/solution/exploit
@@ -65,10 +65,11 @@ def start_remote(argv=[], *a, **kw):
 
 def start(argv=[], *a, **kw):
     '''Start the exploit against the target.'''
-    if args.LOCAL:
-        return start_local(argv, *a, **kw)
-    else:
+    if args.REMOTE:
         return start_remote(argv, *a, **kw)
+    else:
+        return start_local(argv, *a, **kw)
+
 
 # Specify your GDB script here for debugging
 # GDB will be launched if the exploit is run via e.g.

--- a/pwn-nojail-ubuntu24.04/solution/Dockerfile
+++ b/pwn-nojail-ubuntu24.04/solution/Dockerfile
@@ -23,4 +23,4 @@ COPY challenge .
 
 ENV PWNLIB_NOTERM=1
 
-CMD /usr/bin/timeout -k 5 ${TIMEOUT} ./exploit HOST=${HOST} PORT=${PORT}
+CMD /usr/bin/timeout -k 5 ${TIMEOUT} ./exploit REMOTE HOST=${HOST} PORT=${PORT}

--- a/pwn-nojail-ubuntu24.04/solution/exploit
+++ b/pwn-nojail-ubuntu24.04/solution/exploit
@@ -66,10 +66,11 @@ def start_remote(argv=[], *a, **kw):
 
 def start(argv=[], *a, **kw):
     '''Start the exploit against the target.'''
-    if args.LOCAL:
-        return start_local(argv, *a, **kw)
-    else:
+    if args.REMOTE:
         return start_remote(argv, *a, **kw)
+    else:
+        return start_local(argv, *a, **kw)
+
 
 # Specify your GDB script here for debugging
 # GDB will be launched if the exploit is run via e.g.

--- a/pwn-qemu-kernel/solution/Dockerfile
+++ b/pwn-qemu-kernel/solution/Dockerfile
@@ -21,4 +21,4 @@ USER pwntools
 
 ENV PWNLIB_NOTERM=1
 
-CMD /usr/bin/timeout -k 5 ${TIMEOUT} ./exploit HOST=${HOST} PORT=${PORT}
+CMD /usr/bin/timeout -k 5 ${TIMEOUT} ./exploit REMOTE HOST=${HOST} PORT=${PORT}

--- a/pwn-qemu-kernel/solution/exploit
+++ b/pwn-qemu-kernel/solution/exploit
@@ -65,10 +65,11 @@ def start_remote(argv=[], *a, **kw):
 
 def start(argv=[], *a, **kw):
     '''Start the exploit against the target.'''
-    if args.LOCAL:
-        return start_local(argv, *a, **kw)
-    else:
+    if args.REMOTE:
         return start_remote(argv, *a, **kw)
+    else:
+        return start_local(argv, *a, **kw)
+
 
 # Specify your GDB script here for debugging
 # GDB will be launched if the exploit is run via e.g.

--- a/python3.11-jail-alpine3.19/solution/Dockerfile
+++ b/python3.11-jail-alpine3.19/solution/Dockerfile
@@ -21,4 +21,4 @@ USER pwntools
 
 ENV PWNLIB_NOTERM=1
 
-CMD /usr/bin/timeout -k 5 ${TIMEOUT} ./exploit HOST=${HOST} PORT=${PORT}
+CMD /usr/bin/timeout -k 5 ${TIMEOUT} ./exploit REMOTE HOST=${HOST} PORT=${PORT}

--- a/python3.11-jail-alpine3.19/solution/exploit
+++ b/python3.11-jail-alpine3.19/solution/exploit
@@ -59,10 +59,11 @@ def start_remote(argv=[], *a, **kw):
 
 def start(argv=[], *a, **kw):
     '''Start the exploit against the target.'''
-    if args.LOCAL:
-        return start_local(argv, *a, **kw)
-    else:
+    if args.REMOTE:
         return start_remote(argv, *a, **kw)
+    else:
+        return start_local(argv, *a, **kw)
+
 
 # Specify your GDB script here for debugging
 # GDB will be launched if the exploit is run via e.g.

--- a/python3.11-nojail-alpine3.19/solution/Dockerfile
+++ b/python3.11-nojail-alpine3.19/solution/Dockerfile
@@ -21,4 +21,4 @@ USER pwntools
 
 ENV PWNLIB_NOTERM=1
 
-CMD /usr/bin/timeout -k 5 ${TIMEOUT} ./exploit HOST=${HOST} PORT=${PORT}
+CMD /usr/bin/timeout -k 5 ${TIMEOUT} ./exploit REMOTE HOST=${HOST} PORT=${PORT}

--- a/python3.11-nojail-alpine3.19/solution/exploit
+++ b/python3.11-nojail-alpine3.19/solution/exploit
@@ -59,10 +59,11 @@ def start_remote(argv=[], *a, **kw):
 
 def start(argv=[], *a, **kw):
     '''Start the exploit against the target.'''
-    if args.LOCAL:
-        return start_local(argv, *a, **kw)
-    else:
+    if args.REMOTE:
         return start_remote(argv, *a, **kw)
+    else:
+        return start_local(argv, *a, **kw)
+
 
 # Specify your GDB script here for debugging
 # GDB will be launched if the exploit is run via e.g.

--- a/python3.12-jail-ubuntu24.04/solution/Dockerfile
+++ b/python3.12-jail-ubuntu24.04/solution/Dockerfile
@@ -21,4 +21,4 @@ USER pwntools
 
 ENV PWNLIB_NOTERM=1
 
-CMD /usr/bin/timeout -k 5 ${TIMEOUT} ./exploit HOST=${HOST} PORT=${PORT}
+CMD /usr/bin/timeout -k 5 ${TIMEOUT} ./exploit REMOTE HOST=${HOST} PORT=${PORT}

--- a/python3.12-jail-ubuntu24.04/solution/exploit
+++ b/python3.12-jail-ubuntu24.04/solution/exploit
@@ -60,10 +60,11 @@ def start_remote(argv=[], *a, **kw):
 
 def start(argv=[], *a, **kw):
     '''Start the exploit against the target.'''
-    if args.LOCAL:
-        return start_local(argv, *a, **kw)
-    else:
+    if args.REMOTE:
         return start_remote(argv, *a, **kw)
+    else:
+        return start_local(argv, *a, **kw)
+
 
 # Specify your GDB script here for debugging
 # GDB will be launched if the exploit is run via e.g.

--- a/python3.12-nojail-ubuntu24.04/solution/Dockerfile
+++ b/python3.12-nojail-ubuntu24.04/solution/Dockerfile
@@ -21,4 +21,4 @@ USER pwntools
 
 ENV PWNLIB_NOTERM=1
 
-CMD /usr/bin/timeout -k 5 ${TIMEOUT} ./exploit HOST=${HOST} PORT=${PORT}
+CMD /usr/bin/timeout -k 5 ${TIMEOUT} ./exploit REMOTE HOST=${HOST} PORT=${PORT}

--- a/python3.12-nojail-ubuntu24.04/solution/exploit
+++ b/python3.12-nojail-ubuntu24.04/solution/exploit
@@ -59,10 +59,11 @@ def start_remote(argv=[], *a, **kw):
 
 def start(argv=[], *a, **kw):
     '''Start the exploit against the target.'''
-    if args.LOCAL:
-        return start_local(argv, *a, **kw)
-    else:
+    if args.REMOTE:
         return start_remote(argv, *a, **kw)
+    else:
+        return start_local(argv, *a, **kw)
+
 
 # Specify your GDB script here for debugging
 # GDB will be launched if the exploit is run via e.g.

--- a/rust-nojail-alpine3.19/solution/Dockerfile
+++ b/rust-nojail-alpine3.19/solution/Dockerfile
@@ -23,4 +23,4 @@ COPY challenge .
 
 ENV PWNLIB_NOTERM=1
 
-CMD /usr/bin/timeout -k 5 ${TIMEOUT} ./exploit HOST=${HOST} PORT=${PORT}
+CMD /usr/bin/timeout -k 5 ${TIMEOUT} ./exploit REMOTE HOST=${HOST} PORT=${PORT}

--- a/rust-nojail-alpine3.19/solution/exploit
+++ b/rust-nojail-alpine3.19/solution/exploit
@@ -65,10 +65,11 @@ def start_remote(argv=[], *a, **kw):
 
 def start(argv=[], *a, **kw):
     '''Start the exploit against the target.'''
-    if args.LOCAL:
-        return start_local(argv, *a, **kw)
-    else:
+    if args.REMOTE:
         return start_remote(argv, *a, **kw)
+    else:
+        return start_local(argv, *a, **kw)
+
 
 # Specify your GDB script here for debugging
 # GDB will be launched if the exploit is run via e.g.

--- a/rust-nojail-ubuntu24.04/solution/Dockerfile
+++ b/rust-nojail-ubuntu24.04/solution/Dockerfile
@@ -23,4 +23,4 @@ COPY challenge .
 
 ENV PWNLIB_NOTERM=1
 
-CMD /usr/bin/timeout -k 5 ${TIMEOUT} ./exploit HOST=${HOST} PORT=${PORT}
+CMD /usr/bin/timeout -k 5 ${TIMEOUT} ./exploit REMOTE HOST=${HOST} PORT=${PORT}

--- a/rust-nojail-ubuntu24.04/solution/exploit
+++ b/rust-nojail-ubuntu24.04/solution/exploit
@@ -65,10 +65,11 @@ def start_remote(argv=[], *a, **kw):
 
 def start(argv=[], *a, **kw):
     '''Start the exploit against the target.'''
-    if args.LOCAL:
-        return start_local(argv, *a, **kw)
-    else:
+    if args.REMOTE:
         return start_remote(argv, *a, **kw)
+    else:
+        return start_local(argv, *a, **kw)
+
 
 # Specify your GDB script here for debugging
 # GDB will be launched if the exploit is run via e.g.

--- a/sagemath-nojail-ubuntu22.04/solution/Dockerfile
+++ b/sagemath-nojail-ubuntu22.04/solution/Dockerfile
@@ -27,4 +27,4 @@ ENV TERM=linux
 
 WORKDIR /app
 
-CMD "/usr/bin/timeout ${TIMEOUT} ./exploit HOST=${HOST} PORT=${PORT}"
+CMD "/usr/bin/timeout ${TIMEOUT} ./exploit REMOTE HOST=${HOST} PORT=${PORT}"

--- a/sagemath-nojail-ubuntu22.04/solution/exploit
+++ b/sagemath-nojail-ubuntu22.04/solution/exploit
@@ -63,10 +63,11 @@ def start_remote(argv=[], *a, **kw):
 
 def start(argv=[], *a, **kw):
     '''Start the exploit against the target.'''
-    if args.LOCAL:
-        return start_local(argv, *a, **kw)
-    else:
+    if args.REMOTE:
         return start_remote(argv, *a, **kw)
+    else:
+        return start_local(argv, *a, **kw)
+
 
 # Specify your GDB script here for debugging
 # GDB will be launched if the exploit is run via e.g.


### PR DESCRIPTION
Idk why we had `REMOTE` as default and not `LOCAL`, for when people develop exploits locally. We also have to specify that we run on `REMOTE` on the `Dockerfile`