### PR TITLE
pwn-qemu-kernel: fix qemu n-day

### DIFF
--- a/pwn-qemu-kernel/Makefile
+++ b/pwn-qemu-kernel/Makefile
@@ -52,7 +52,7 @@ export NAME=$(shell echo ${UNCLEAN_NAME} | tr "[:upper:]" "[:lower:]")
 # Major: Big features & breakage of interfaces                  (in sync)
 # Minor: Small functionality changes w/ backward compatibility  (in sync)
 # Patch: Small fixes specific to this template                  (not in sync)
-export _VERSION = 1.0.1
+export _VERSION = 1.0.2
 export _TEMPLATE = pwn-qemu-kernel
 
 ########################

--- a/pwn-qemu-kernel/challenge/Dockerfile
+++ b/pwn-qemu-kernel/challenge/Dockerfile
@@ -14,10 +14,10 @@
 #################
 # Runner system #
 #################
-FROM docker.io/library/ubuntu@sha256:1e622c5f073b4f6bfad6632f2616c7f59ef256e96fe78bf6a595d1dc4376ac02 as base
+FROM docker.io/library/fedora@sha256:6cd815d862109208adf6040ea13391fe6aeb87a9dc80735c2ab07083fdf5e03a as base
 
 # Install apt dependencies if needed
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y socat bash ruby libguestfs-tools openssh-client qemu-system-x86 && apt-get clean 
+RUN dnf update -y && dnf install -y socat bash ruby libguestfs-tools openssh-clients qemu-system-x86 && dnf clean -y all
 
 # Copy kernel images & modules
 COPY buildroot/rootfs.qcow2 /app/


### PR DESCRIPTION
Fix https://kqx.io/post/qemu-nday/ by using Fedora 43 as base image.

Maybe we want to use rawhide. Or something else, I used Fedora as I new it would have a fresh version. I tried RHEL Ubi images but it did not have half of the packages.

This is one of the cases where we might not want to lock the repository packages, as we want qemu to update.

```
bash-5.3$ qemu-system-x86_64 --version
QEMU emulator version 10.1.2 (qemu-10.1.2-1.fc43)
Copyright (c) 2003-2025 Fabrice Bellard and the QEMU Project developers
```

Makes sense to use always latest qemu, the container is privileged, we also dont want anything else to be found and get a escape.